### PR TITLE
Update Keycloak Login Button Label and Icon for Clarity

### DIFF
--- a/ckanext/keycloak/templates/user/new.html
+++ b/ckanext/keycloak/templates/user/new.html
@@ -18,7 +18,7 @@
       {{ form | safe }}
 
       {% block login_button %}
- <a class="gbtn btn btn-default google-button" href="{{ h.url_for('keycloak.sso') }}">{{ _('Sign in with Google') }}</a>
+ <a class="btn btn-default" href="{{ h.url_for('keycloak.sso') }}"><i class="fa fa-lock "></i> {{ _('Sign in with SSO') }}</a>
     {% endblock %}
 </div>
 

--- a/ckanext/keycloak/templates/user/snippets/login_form.html
+++ b/ckanext/keycloak/templates/user/snippets/login_form.html
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% ckan_extends %}
 {% block login_button %}
- <a class="gbtn btn btn-default" href="{{ h.url_for('keycloak.sso') }}">{{ _('Sign in with Google') }}</a>
+ <a class="btn btn-default" href="{{ h.url_for('keycloak.sso') }}"><i class="fa fa-lock "></i> {{ _('Sign in with SSO') }}</a>
  <button class="btn btn-primary" type="submit">{{ _('Login') }}</button>
  
 {% endblock %}


### PR DESCRIPTION
**Summary**
This PR updates the label and icon of the Keycloak login button to better reflect its functionality. The label has been changed from "Sign in with Google" to "Sign in with SSO," and the Google logo has been replaced with a lock icon.

**Changes**
Updated button label to "Sign in with SSO"
Replaced Google logo with a lock icon

**Rationale**
The previous label and icon could be misleading, as the button is used for Single Sign-On (SSO) via Keycloak, not specifically for Google authentication. The new label and icon aim to provide a more accurate representation of the button's functionality.

**Testing**
Manually tested the changes to ensure that the new label and icon appear correctly and that the button still functions as expected.

Feel free to modify this to better suit the project's contribution guidelines or to add any additional information you think might be relevant.

<img width="401" alt="Screenshot 2023-09-20 at 11 52 56" src="https://github.com/keitaroinc/ckanext-keycloak/assets/1210046/f2483f0e-e9d4-4138-95ac-3c2361db7444">

